### PR TITLE
Check for an ID on the achiever when syncing

### DIFF
--- a/src/EntityRelationsAchievements.php
+++ b/src/EntityRelationsAchievements.php
@@ -22,7 +22,7 @@ trait EntityRelationsAchievements
      */
     public function achievements(): MorphMany
     {
-        if (config('achievements.locked_sync')) {
+        if (config('achievements.locked_sync') && !empty($this->id) {
             $this->syncAchievements();
         }
         return $this->morphMany(AchievementProgress::class, 'achiever')


### PR DESCRIPTION
This prevents errors when auto sync is turned on and loading in related achiever models when the ID is not fetched from the database